### PR TITLE
Manual updater for Hashlist and some Code/Dependency updates

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,4 +1,5 @@
-﻿<prism:PrismApplication x:Class="DieselBundleViewer.App"
+﻿<prism:PrismApplication 
+             x:Class="DieselBundleViewer.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:DieselBundleViewer"

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -55,6 +55,7 @@ namespace DieselBundleViewer
         protected override void RegisterTypes(IContainerRegistry containerRegistry)
         {
             containerRegistry.RegisterDialog<ConvertFileDialog, ConvertFileDialogViewModel>();
+            containerRegistry.RegisterDialog<UpdateHashlistDialog, UpdateHashlistDialogViewModel>();
             containerRegistry.RegisterDialog<AboutDialog, AboutDialogViewModel>();
             containerRegistry.RegisterDialog<SettingsDialog, SettingsDialogViewModel>();
             containerRegistry.RegisterDialog<FindDialog, FindDialogViewModel>();
@@ -193,13 +194,13 @@ namespace DieselBundleViewer
                     for (int i = 0; i < str.LocalizationStrings.Count; i++)
                     {
                         StringEntry entry = str.LocalizationStrings[i];
-                        builder.Append("\t");
+                        builder.Append('\t');
                         builder.Append("\"" + entry.ID + "\" : \"" + entry.Text + "\"");
                         if (i < str.LocalizationStrings.Count - 1)
-                            builder.Append(",");
-                        builder.Append("\n");
+                            builder.Append(',');
+                        builder.Append('\n');
                     }
-                    builder.Append("}");
+                    builder.Append('}');
                     Console.WriteLine(builder.ToString());
                     return builder.ToString();
                 },

--- a/DieselBundleViewer.csproj
+++ b/DieselBundleViewer.csproj
@@ -72,9 +72,4 @@
 	<ItemGroup>
 		<Folder Include="Converter\" />
 	</ItemGroup>
-	<ItemGroup>
-	  <Compile Update="ViewModels\UpdateHashlistDialogViewModel.cs">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Compile>
-	</ItemGroup>
 </Project>

--- a/DieselBundleViewer.csproj
+++ b/DieselBundleViewer.csproj
@@ -1,75 +1,80 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
-    <UseWPF>true</UseWPF>
-    <AssemblyName>DieselBundleViewer</AssemblyName>
-    <ApplicationIcon>favicon.ico</ApplicationIcon>
-    <StartupObject>DieselBundleViewer.App</StartupObject>
-    <Version>1.1.5</Version>
-    <Company>ModWorkshop</Company>
-    <Authors>https://github.com/Luffyyy</Authors>
-    <UseWindowsForms>true</UseWindowsForms>
-    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <RollForward>Major</RollForward>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Assets\arrow-left-dark.png" />
-    <None Remove="Assets\arrow-left.png" />
-    <None Remove="Assets\arrow-right-dark.png" />
-    <None Remove="Assets\arrow-right.png" />
-    <None Remove="Assets\arrow_left.png" />
-    <None Remove="Assets\arrow_left_dark.png" />
-    <None Remove="Assets\arrow_right.png" />
-    <None Remove="Assets\arrow_right_dark.png" />
-    <None Remove="Assets\file.png" />
-    <None Remove="Assets\file_dark.png" />
-    <None Remove="Assets\folder.png" />
-    <None Remove="Assets\folder_dark.png" />
-    <None Remove="Assets\font.png" />
-    <None Remove="Assets\grid.png" />
-    <None Remove="Assets\image.png" />
-    <None Remove="Assets\list.png" />
-    <None Remove="Assets\lua.png" />
-    <None Remove="Assets\video.png" />
-    <None Remove="favicon.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="Assets\font.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="AdonisUI" Version="1.17.1" />
-    <PackageReference Include="AdonisUI.ClassicTheme" Version="1.17.1" />
-    <PackageReference Include="CS-Script.Core" Version="1.3.1" />
-    <PackageReference Include="IronPython" Version="2.7.12" />
-    <PackageReference Include="Prism.Core" Version="8.1.97" />
-    <PackageReference Include="Prism.DryIoc" Version="8.1.97" />
-    <PackageReference Include="Prism.Wpf" Version="8.1.97" />
-    <PackageReference Include="The.Microsoft.Expression.Interactions" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <Resource Include="Assets\arrow-left-dark.png" />
-    <Resource Include="Assets\arrow-left.png" />
-    <Resource Include="Assets\arrow-right-dark.png" />
-    <Resource Include="Assets\arrow-right.png" />
-    <Resource Include="Assets\file.png" />
-    <Resource Include="Assets\folder.png" />
-    <Resource Include="Assets\grid.png" />
-    <Resource Include="Assets\image.png" />
-    <Resource Include="Assets\list.png" />
-    <Resource Include="Assets\lua.png" />
-    <Resource Include="Assets\video.png" />
-    <Resource Include="favicon.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="DieselEngineFormats">
-      <HintPath>dlls\DieselEngineFormats.dll</HintPath>
-    </Reference>
-    <Reference Include="Wwise Sound Library">
-      <HintPath>dlls\Wwise Sound Library.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Converter\" />
-  </ItemGroup>
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net8.0-windows7.0</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<AssemblyName>DieselBundleViewer</AssemblyName>
+		<ApplicationIcon>favicon.ico</ApplicationIcon>
+		<StartupObject>DieselBundleViewer.App</StartupObject>
+		<Version>1.1.5</Version>
+		<Company>ModWorkshop</Company>
+		<Authors>https://github.com/Luffyyy</Authors>
+		<UseWindowsForms>true</UseWindowsForms>
+		<SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+		<RollForward>Major</RollForward>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Remove="Assets\arrow-left-dark.png" />
+		<None Remove="Assets\arrow-left.png" />
+		<None Remove="Assets\arrow-right-dark.png" />
+		<None Remove="Assets\arrow-right.png" />
+		<None Remove="Assets\arrow_left.png" />
+		<None Remove="Assets\arrow_left_dark.png" />
+		<None Remove="Assets\arrow_right.png" />
+		<None Remove="Assets\arrow_right_dark.png" />
+		<None Remove="Assets\file.png" />
+		<None Remove="Assets\file_dark.png" />
+		<None Remove="Assets\folder.png" />
+		<None Remove="Assets\folder_dark.png" />
+		<None Remove="Assets\font.png" />
+		<None Remove="Assets\grid.png" />
+		<None Remove="Assets\image.png" />
+		<None Remove="Assets\list.png" />
+		<None Remove="Assets\lua.png" />
+		<None Remove="Assets\video.png" />
+		<None Remove="favicon.ico" />
+	</ItemGroup>
+	<ItemGroup>
+		<Resource Include="Assets\font.png" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AdonisUI" Version="1.17.1" />
+		<PackageReference Include="AdonisUI.ClassicTheme" Version="1.17.1" />
+		<PackageReference Include="CS-Script.Core" Version="2.0.0" />
+		<PackageReference Include="IronPython" Version="3.4.1" />
+		<PackageReference Include="Prism.Core" Version="9.0.537" />
+		<PackageReference Include="Prism.DryIoc" Version="9.0.537" />
+		<PackageReference Include="Prism.Wpf" Version="9.0.537" />
+		<PackageReference Include="The.Microsoft.Expression.Interactions" Version="4.5.0" />
+	</ItemGroup>
+	<ItemGroup>
+		<Resource Include="Assets\arrow-left-dark.png" />
+		<Resource Include="Assets\arrow-left.png" />
+		<Resource Include="Assets\arrow-right-dark.png" />
+		<Resource Include="Assets\arrow-right.png" />
+		<Resource Include="Assets\file.png" />
+		<Resource Include="Assets\folder.png" />
+		<Resource Include="Assets\grid.png" />
+		<Resource Include="Assets\image.png" />
+		<Resource Include="Assets\list.png" />
+		<Resource Include="Assets\lua.png" />
+		<Resource Include="Assets\video.png" />
+		<Resource Include="favicon.ico" />
+	</ItemGroup>
+	<ItemGroup>
+		<Reference Include="DieselEngineFormats">
+			<HintPath>dlls\DieselEngineFormats.dll</HintPath>
+		</Reference>
+		<Reference Include="Wwise Sound Library">
+			<HintPath>dlls\Wwise Sound Library.dll</HintPath>
+		</Reference>
+	</ItemGroup>
+	<ItemGroup>
+		<Folder Include="Converter\" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Compile Update="ViewModels\UpdateHashlistDialogViewModel.cs">
+	    <Generator>MSBuild:Compile</Generator>
+	  </Compile>
+	</ItemGroup>
 </Project>

--- a/DieselBundleViewer.sln
+++ b/DieselBundleViewer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30104.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35222.181
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DieselBundleViewer", "DieselBundleViewer.csproj", "{7EB10C1B-314D-459E-A8B5-C41DD70019B7}"
 EndProject

--- a/Models/FolderEntry.cs
+++ b/Models/FolderEntry.cs
@@ -11,9 +11,9 @@ using System.Text;
 
 namespace DieselBundleViewer.Models
 {
-    public class FolderEntry : IEntry
+    public class FolderEntry(uint level = 0) : IEntry
     {
-        public SortedDictionary<string, IEntry> Children { get; set; }
+        public SortedDictionary<string, IEntry> Children { get; set; } = new SortedDictionary<string, IEntry>();
 
         public FolderEntry Parent { get; set; }
         public string EntryPath { get; set; }
@@ -41,12 +41,7 @@ namespace DieselBundleViewer.Models
 
         public string Type => "File folder";
 
-        private uint folderLevel;
-
-        public FolderEntry(uint level = 0) {
-            folderLevel = level;
-            Children = new SortedDictionary<string, IEntry>();
-        }
+        private uint folderLevel = level;
 
         public FolderEntry(FileEntry entry, uint level = 0) : this(level)
         {

--- a/Objects/PageData.cs
+++ b/Objects/PageData.cs
@@ -11,9 +11,9 @@ namespace DieselBundleViewer.Objects
         Size
     }
 
-    public class PageData
+    public class PageData(string path)
     {
-        public string Path { get; set; }
+        public string Path { get; set; } = path;
         public string Search { get; set; }
         public bool MatchWord { get; set; }
         public bool UseRegex { get; set; }
@@ -21,9 +21,5 @@ namespace DieselBundleViewer.Objects
         public bool FullPath { get; set; }
         public Sorting SortBy { get; set; } = Sorting.Name;
         public bool Ascending { get; set; } = true;
-        public PageData(string path)
-        {
-            Path = path;
-        }
     }
 }

--- a/Objects/VirtualFileDataObject.cs
+++ b/Objects/VirtualFileDataObject.cs
@@ -648,48 +648,37 @@ namespace DieselBundleViewer.Services
         /// </remarks>
         /// <typeparam name="T1">The type of the tuple's first component.</typeparam>
         /// <typeparam name="T2">The type of the tuple's second component.</typeparam>
-        private class Tuple<T1, T2>
+        /// <remarks>
+        /// Initializes a new instance of the Tuple(T1, T2) class.
+        /// </remarks>
+        /// <param name="item1">The value of the tuple's first component.</param>
+        /// <param name="item2">The value of the tuple's second component.</param>
+        private class Tuple<T1, T2>(T1 item1, T2 item2)
         {
             /// <summary>
             /// Gets the value of the current Tuple(T1, T2) object's first component.
             /// </summary>
-            public T1 Item1 { get; private set; }
+            public T1 Item1 { get; private set; } = item1;
 
             /// <summary>
             /// Gets the value of the current Tuple(T1, T2) object's second component.
             /// </summary>
-            public T2 Item2 { get; private set; }
-
-            /// <summary>
-            /// Initializes a new instance of the Tuple(T1, T2) class.
-            /// </summary>
-            /// <param name="item1">The value of the tuple's first component.</param>
-            /// <param name="item2">The value of the tuple's second component.</param>
-            public Tuple(T1 item1, T2 item2)
-            {
-                Item1 = item1;
-                Item2 = item2;
-            }
+            public T2 Item2 { get; private set; } = item2;
         }
 
         /// <summary>
         /// Simple class that exposes a write-only IStream as a Stream.
         /// </summary>
-        private class IStreamWrapper : Stream
+        /// <remarks>
+        /// Initializes a new instance of the IStreamWrapper class.
+        /// </remarks>
+        /// <param name="iStream">IStream instance to wrap.</param>
+        private class IStreamWrapper(IStream iStream) : Stream
         {
             /// <summary>
             /// IStream instance being wrapped.
             /// </summary>
-            private IStream _iStream;
-
-            /// <summary>
-            /// Initializes a new instance of the IStreamWrapper class.
-            /// </summary>
-            /// <param name="iStream">IStream instance to wrap.</param>
-            public IStreamWrapper(IStream iStream)
-            {
-                _iStream = iStream;
-            }
+            private IStream _iStream = iStream;
 
             /// <summary>
             /// Gets a value indicating whether the current stream supports reading.

--- a/Services/DragDropController.cs
+++ b/Services/DragDropController.cs
@@ -2,34 +2,25 @@
 using DieselBundleViewer.ViewModels;
 using DieselEngineFormats.Bundle;
 using Prism.Events;
-using Prism.Services.Dialogs;
+using Prism.Dialogs;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 
 namespace DieselBundleViewer.Services
 {    public class StartProgress : PubSubEvent { }
 
-    class DragDropController
+    class DragDropController(bool outputFullPaths)
     {
-        public bool OutputFullPaths = false;
-        private TextBox Control { get; set; }
+        public bool OutputFullPaths = outputFullPaths;
+        private TextBox Control { get; set; } = new TextBox();
 
         private ProgressDialogViewModel Progress;
 
         private EventAggregator Aggregator;
-
-        public DragDropController(bool outputFullPaths)
-        {
-            Control = new TextBox();
-            OutputFullPaths = outputFullPaths;
-        }
 
         public void DoDragDrop(List<IEntry> entries)
         {

--- a/Services/HashlistUpdater.cs
+++ b/Services/HashlistUpdater.cs
@@ -1,0 +1,84 @@
+﻿using DieselEngineFormats.Bundle;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace DieselBundleViewer.Services
+{
+    public static class HashlistUpdater
+    {
+        private const string _localHashlistPath = "Data/hashlist";
+        private const string _remoteHashlistInfoUrl = "https://api.github.com/repos/Luffyyy/PAYDAY-2-Hashlist/branches/master";
+        private const string _remoteHashlistLatestUrl = "https://raw.githubusercontent.com/Luffyyy/PAYDAY-2-Hashlist/master/hashlist";
+        private const string _firefoxUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:129.0) Gecko/20100101 Firefox/129.0";
+
+        private static DateTime? _localHashlistLatestUpdate = null;
+        private static DateTime? _remoteHashlistLatestUpdate = null;
+        private static HttpClient _httpClient = null;
+
+        public static async Task DownloadLatestHashlist()
+        {
+            var client = GetOrInitHttpClient();
+            var response = await client.GetStringAsync(_remoteHashlistLatestUrl);
+
+            using var streamWriter = new StreamWriter(_localHashlistPath, false);
+            streamWriter.Write(response.ToString());
+            streamWriter.Flush();
+            streamWriter.Close();
+
+            ReloadHashIndex();
+        }
+
+        public static bool? IsHashlistUpToDate()
+        {
+            if (!File.Exists(_localHashlistPath))
+                return null;
+
+            if (!_localHashlistLatestUpdate.HasValue)
+                _localHashlistLatestUpdate = File.GetLastWriteTimeUtc(_localHashlistPath);
+
+            if (!_remoteHashlistLatestUpdate.HasValue)
+            {
+                var client = GetOrInitHttpClient();
+
+                var response = client.GetStringAsync(_remoteHashlistInfoUrl);
+                var branchInfo = JsonNode.Parse(response.Result.ToString());
+
+                // The path down the JSON here is a bit annoying but I don't need any of this data
+                var latestDate = branchInfo?["commit"]["commit"]["author"]["date"]?.ToString();
+
+                if (latestDate != null)
+                    _remoteHashlistLatestUpdate = DateTime.Parse(latestDate);
+            }
+
+            return _localHashlistLatestUpdate >= _remoteHashlistLatestUpdate;
+        }
+
+        private static HttpClient GetOrInitHttpClient()
+        {
+            if (_httpClient == null)
+            {
+                HttpClient client = new HttpClient();
+                // GitHub API has a free limit but not having a User-Agent excludes you from even that
+                client.DefaultRequestHeaders.Add(
+                    "User-Agent",
+                    _firefoxUserAgent
+                );
+
+                _httpClient = client;
+            }
+
+            return _httpClient;
+        }
+        private static void ReloadHashIndex()
+        {
+            HashIndex.Clear();
+            HashIndex.LoadParallel(_localHashlistPath);
+        }
+    }
+}

--- a/Services/HashlistUpdater.cs
+++ b/Services/HashlistUpdater.cs
@@ -1,10 +1,7 @@
 ﻿using DieselEngineFormats.Bundle;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 

--- a/Services/JSONNode.cs
+++ b/Services/JSONNode.cs
@@ -24,7 +24,7 @@ namespace DieselBundleViewer.Services
             {
                 StringBuilder indentation = new StringBuilder();
                 for (int i = 0; i < this.indent; i++)
-                    indentation.Append("\t");
+                    indentation.Append('\t');
 
                 StringBuilder sb = new StringBuilder();
 
@@ -58,7 +58,7 @@ namespace DieselBundleViewer.Services
 
                     if (kvp.Value is float[])
                     {
-                        sb.Append("\"");
+                        sb.Append('"');
                         float[] vals = kvp.Value as float[];
 
                         if (vals.Length == 3)
@@ -78,7 +78,7 @@ namespace DieselBundleViewer.Services
 
                             //sb.Append("Rotation(" + (-vec.x).ToString() + ", " + vec.y.ToString() + ", " + (-vec.z).ToString() + ")");
                         }
-                        sb.Append("\"");
+                        sb.Append('"');
                     }
                     else if (kvp.Value is bool)
                         sb.Append(((bool)kvp.Value ? "true" : "false"));

--- a/Services/ScriptActions.cs
+++ b/Services/ScriptActions.cs
@@ -1,4 +1,5 @@
-﻿using CSScriptLib;
+﻿using CSScripting;
+using CSScriptLib;
 using DieselBundleViewer.Models;
 using IronPython.Hosting;
 using Microsoft.Scripting.Hosting;
@@ -15,8 +16,8 @@ namespace DieselBundleViewer.Services
 {
     public static class ScriptActions
     {
-        public static Dictionary<string, Dictionary<string, FormatConverter>> Converters = new Dictionary<string, Dictionary<string, FormatConverter>>();
-        public static List<Script> Scripts = new List<Script>();
+        public static Dictionary<string, Dictionary<string, FormatConverter>> Converters = [];
+        public static List<Script> Scripts = [];
         public static ScriptEngine PythonEngine;
 
         public static string ScriptsFolder = "Scripts";
@@ -33,10 +34,10 @@ namespace DieselBundleViewer.Services
 
             var folders = Directory.EnumerateDirectories(ScriptsFolder);
             
-            if (folders.Count() == 0)
+            if (!folders.Any())
                 return;
 
-            Stopwatch watch = new Stopwatch();
+            Stopwatch watch = new();
             watch.Start();
             Console.WriteLine("Attempting to load scripts...");
 
@@ -48,8 +49,7 @@ namespace DieselBundleViewer.Services
                     if (File.Exists(main_path = Path.Combine(folder, "main.py")))
                     {
                         Console.WriteLine(".???");
-                        if (PythonEngine == null)
-                            PythonEngine = Python.CreateEngine();
+                        PythonEngine ??= Python.CreateEngine();
 
                         dynamic scope = PythonEngine.CreateScope();
                         foreach (string file in Directory.GetFiles(folder))
@@ -100,7 +100,7 @@ namespace DieselBundleViewer.Services
             }
 
             if (!Converters.ContainsKey(format.Type))
-                Converters.Add(format.Type, new Dictionary<string, FormatConverter>());
+                Converters.Add(format.Type, []);
 
             if (Converters[format.Type].ContainsKey(format.Key))
             {
@@ -138,10 +138,10 @@ namespace DieselBundleViewer.Services
 
         public static FormatConverter GetConverter(string type, string key)
         {
-            if (!Converters.ContainsKey(type) || !Converters[type].ContainsKey(key))
+            if (!Converters.TryGetValue(type, out Dictionary<string, FormatConverter> value) || !value.ContainsKey(key))
                 return null;
 
-            return Converters[type][key];
+            return value[key];
         }
     }
 

--- a/Services/Settings.cs
+++ b/Services/Settings.cs
@@ -1,10 +1,6 @@
-﻿using AdonisUI.Controls;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Xml;
 using System.Xml.Serialization;
 
 namespace DieselBundleViewer.Services
@@ -13,8 +9,9 @@ namespace DieselBundleViewer.Services
     {
         public bool DisplayEmptyFiles { get; set; } = false;
         public bool ExtractFullDir { get; set; } = false;
-        public bool DarkMode { get; set; }  = true;
-        public List<string> RecentFiles = new List<string>();
+        public bool DarkMode { get; set; } = true;
+        public List<string> RecentFiles = [];
+        public DateTime HaslistLastUpdate { get; set; }
     }
 
     public static class Settings
@@ -39,11 +36,12 @@ namespace DieselBundleViewer.Services
                 try
                 {
                     Data = (SettingsData)xml.Deserialize(fs);
-                } catch (Exception e)
-                {
-                    Console.WriteLine("Error while reading settings file: "+e.Message);
                 }
-                if(Data == null)
+                catch (Exception e)
+                {
+                    Console.WriteLine("Error while reading settings file: " + e.Message);
+                }
+                if (Data == null)
                 {
                     Console.WriteLine("Settings file is corrupted. Creating a new one.");
                     SaveSettings();
@@ -65,7 +63,8 @@ namespace DieselBundleViewer.Services
                 using var fs = new FileStream(FILE, FileMode.Create, FileAccess.Write);
                 xml.Serialize(fs, Data);
                 Console.WriteLine("Saved settings");
-            } catch (Exception e)
+            }
+            catch (Exception e)
             {
                 Console.WriteLine("Failed saving settings " + e.Message);
             }

--- a/Services/Settings.cs
+++ b/Services/Settings.cs
@@ -11,7 +11,6 @@ namespace DieselBundleViewer.Services
         public bool ExtractFullDir { get; set; } = false;
         public bool DarkMode { get; set; } = true;
         public List<string> RecentFiles = [];
-        public DateTime HaslistLastUpdate { get; set; }
     }
 
     public static class Settings

--- a/Services/Utils.cs
+++ b/Services/Utils.cs
@@ -1,13 +1,10 @@
 ﻿using DieselBundleViewer.ViewModels;
-using DieselBundleViewer.Views;
-using Prism.Ioc;
-using Prism.Services.Dialogs;
+using Prism.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Windows;
 
 namespace DieselBundleViewer.Services
@@ -97,7 +94,7 @@ namespace DieselBundleViewer.Services
         public static string GetDirectory(string path)
         {
             string[] splt = path.Split("/");
-            return string.Join("/", splt.Take(splt.Count() - 1));
+            return string.Join("/", splt.Take(splt.Length - 1));
         }
 
         /// <summary>

--- a/Services/Utils.cs
+++ b/Services/Utils.cs
@@ -152,5 +152,5 @@ namespace DieselBundleViewer.Services
             else
                 return false;
         }
-}
+    }
 }

--- a/ViewModels/AboutDialogViewModel.cs
+++ b/ViewModels/AboutDialogViewModel.cs
@@ -1,10 +1,4 @@
 ﻿using DieselBundleViewer.Services;
-using Prism.Commands;
-using Prism.Mvvm;
-using Prism.Services.Dialogs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace DieselBundleViewer.ViewModels
 {

--- a/ViewModels/BundleSelectorDialogViewModel.cs
+++ b/ViewModels/BundleSelectorDialogViewModel.cs
@@ -1,24 +1,14 @@
 ﻿using DieselEngineFormats.Bundle;
-using ImTools;
-using Prism.Commands;
-using Prism.Mvvm;
-using Prism.Services.Dialogs;
-using System;
+using Prism.Dialogs;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace DieselBundleViewer.ViewModels
 {
-    public class ListBundle : ListItemViewModelBase
+    public class ListBundle(Idstring ids) : ListItemViewModelBase
     {
-        public string Name { get; set; }
-        public Idstring Ids { get; set; }
-        public ListBundle(Idstring ids)
-        {
-            Ids = ids;
-            Name = ids.ToString();
-        }
+        public string Name { get; set; } = ids.ToString();
+        public Idstring Ids { get; set; } = ids;
     }
     public class BundleSelectorDialogViewModel : DialogBase
     {

--- a/ViewModels/ConvertFileDialogViewModel.cs
+++ b/ViewModels/ConvertFileDialogViewModel.cs
@@ -1,8 +1,5 @@
 ﻿using DieselBundleViewer.Services;
-using Prism.Commands;
-using Prism.Mvvm;
-using Prism.Services.Dialogs;
-using System;
+using Prism.Dialogs;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/ViewModels/DialogBase.cs
+++ b/ViewModels/DialogBase.cs
@@ -1,10 +1,7 @@
 ﻿using DieselBundleViewer.Services;
 using Prism.Commands;
+using Prism.Dialogs;
 using Prism.Mvvm;
-using Prism.Services.Dialogs;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace DieselBundleViewer.ViewModels
 {
@@ -12,12 +9,13 @@ namespace DieselBundleViewer.ViewModels
     {
         public virtual string Title => "";
 
-        public event Action<IDialogResult> RequestClose;
         public DelegateCommand<string> CloseDialog { get; }
 
         protected IDialogParameters Params;
 
         public bool IsClosed { get; private set; }
+
+        public DialogCloseListener RequestClose { get; }
 
         public DialogBase()
         {
@@ -45,7 +43,7 @@ namespace DieselBundleViewer.ViewModels
         private void CloseDialogExec(string success)
         {
             PreCloseDialog(success);
-            RequestClose?.Invoke(new DialogResult(success == "True" ? ButtonResult.OK : ButtonResult.Cancel, Params));
+            RequestClose.Invoke(Params, success == "True" ? ButtonResult.OK : ButtonResult.Cancel);
         }
 
         protected virtual void PreCloseDialog(string success) { }

--- a/ViewModels/EntryViewModel.cs
+++ b/ViewModels/EntryViewModel.cs
@@ -91,7 +91,7 @@ namespace DieselBundleViewer.ViewModels
 
         void OpenFileInfoExec()
         {
-            var pms = new Prism.Services.Dialogs.DialogParameters
+            var pms = new Prism.Dialogs.DialogParameters
             {
                 { "Entry", this }
             };

--- a/ViewModels/FindDialogViewModel.cs
+++ b/ViewModels/FindDialogViewModel.cs
@@ -1,11 +1,4 @@
-﻿using Prism.Commands;
-using Prism.Mvvm;
-using Prism.Services.Dialogs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace DieselBundleViewer.ViewModels
+﻿namespace DieselBundleViewer.ViewModels
 {
     public class FindDialogViewModel : DialogBase
     {

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -7,15 +7,15 @@ using DieselEngineFormats.Bundle;
 using DieselEngineFormats.Utils;
 using Microsoft.Win32;
 using Prism.Commands;
+using Prism.Dialogs;
 using Prism.Mvvm;
-using Prism.Services.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,20 +55,21 @@ namespace DieselBundleViewer.ViewModels
         public ObservableCollection<EntryViewModel> ToRender { get; set; }
         public ObservableCollection<TreeEntryViewModel> FoldersToRender { get; set; }
 
-        public List<Script> Scripts => ScriptActions.Scripts;
-        public bool ScriptsVisible => Scripts.Count > 0;
+        public static List<Script> Scripts => ScriptActions.Scripts;
+        public static bool ScriptsVisible => Scripts.Count > 0;
         public ObservableCollection<string> RecentFiles { get; set; }
         public bool RecentFilesVis => RecentFiles.Count > 0;
 
         public List<Idstring> Bundles { get; set; }
         public List<Idstring> SelectedBundles { get; set; }
 
-        public LinkedList<PageData> Pages = new LinkedList<PageData>();
+        public LinkedList<PageData> Pages = new();
         public LinkedListNode<PageData> CurrentPage;
         public string CurrentDir { get => CurrentPage?.Value.Path; set => Navigate(value); }
 
         public DelegateCommand OpenFileDialog { get; }
         public DelegateCommand<string> OpenFile { get; }
+        public DelegateCommand OpenUpdateHashlistDialog { get; }
         public DelegateCommand OpenAboutDialog { get; }
         public DelegateCommand OpenSettingsDialog { get; }
         public DelegateCommand OpenFindDialog { get; }
@@ -99,12 +100,12 @@ namespace DieselBundleViewer.ViewModels
             Utils.CurrentWindow = this;
 
             //Lists and stuff for the bundles/files/etc
-            PackageHeaders = new Dictionary<Idstring, PackageHeader>();
-            Bundles = new List<Idstring>();
-            ToRender = new ObservableCollection<EntryViewModel>();
-            FoldersToRender = new ObservableCollection<TreeEntryViewModel>();
-            SelectedBundles = new List<Idstring>();
-            RawFiles = new Dictionary<Tuple<Idstring, Idstring, Idstring>, FileEntry>();
+            PackageHeaders = [];
+            Bundles = [];
+            ToRender = [];
+            FoldersToRender = [];
+            SelectedBundles = [];
+            RawFiles = [];
             RecentFiles = new ObservableCollection<string>(Settings.Data.RecentFiles);
 
             //Commands / Events
@@ -117,6 +118,7 @@ namespace DieselBundleViewer.ViewModels
             ForwardDir = new DelegateCommand(ForwardDirExec, ()=> CurrentPage?.Next != null);
             OnKeyDown = new DelegateCommand(OnKeyDownExec);
             SetViewStyle = new DelegateCommand<string>(style => SetViewStyleExec(style, true));
+            OpenUpdateHashlistDialog = new DelegateCommand(() => Utils.ShowDialog("UpdateHashlistDialog", null, true));
             OpenAboutDialog = new DelegateCommand(() => Utils.ShowDialog("AboutDialog", null, true));
             OpenSettingsDialog = new DelegateCommand(() => Utils.ShowDialog("SettingsDialog", r => UpdateSettings()));
             OpenHowToUse = new DelegateCommand(() => Utils.OpenURL("https://github.com/Luffyyy/DieselBundleViewer/wiki/How-to-Use"));
@@ -180,7 +182,7 @@ namespace DieselBundleViewer.ViewModels
 
         void OpenBundleSelectorDialogExec()
         {
-            DialogParameters pms = new DialogParameters
+            DialogParameters pms = new()
             {
                 { "Bundles", Bundles }
             };
@@ -236,12 +238,12 @@ namespace DieselBundleViewer.ViewModels
 
         public void OnMouseMoved(Point pos)
         {
-            Point diff = new Point(pos.X - DragStartLocation.X, pos.Y - DragStartLocation.Y);
+            Point diff = new(pos.X - DragStartLocation.X, pos.Y - DragStartLocation.Y);
             if (DragStart)
             {
                 if (Math.Abs(diff.X) > 4 && Math.Abs(diff.Y) > 4)
                 {
-                    DragDropController controller = new DragDropController(Settings.Data.ExtractFullDir);
+                    DragDropController controller = new(Settings.Data.ExtractFullDir);
                     var selected = new List<IEntry>();
                     foreach(var vm in ToRender)
                     {
@@ -270,7 +272,7 @@ namespace DieselBundleViewer.ViewModels
 
         public async void OpenFileDialogExec()
         {
-            OpenFileDialog ofd = new OpenFileDialog { Filter = "Bundle Database File (*.blb)|*.blb"};
+            OpenFileDialog ofd = new() { Filter = "Bundle Database File (*.blb)|*.blb"};
             
             //Here we try to default to 2 very possible directories of PD2 which most users will use it for.
             if(!RecentFilesVis)
@@ -293,15 +295,14 @@ namespace DieselBundleViewer.ViewModels
                 string fileName = ofd.FileName;
 
                 //If the file already exists in the recents, bump it.
-                if (RecentFiles.Contains(fileName))
-                    RecentFiles.Remove(fileName);
+                RecentFiles.Remove(fileName);
 
                 RecentFiles.Insert(0, fileName);
 
-                Settings.Data.RecentFiles = RecentFiles.ToList();
+                Settings.Data.RecentFiles = [.. RecentFiles];
                 Settings.SaveSettings();
 
-                RaisePropertyChanged("RecentFilesVis");
+                RaisePropertyChanged(nameof(RecentFilesVis));
 
                 await OpenBLBFile(fileName);
             }
@@ -326,8 +327,7 @@ namespace DieselBundleViewer.ViewModels
 
         public void CloseBLBExec()
         {
-            if (cancelLastTask != null)
-                cancelLastTask.Cancel();
+            cancelLastTask?.Cancel();
 
             Status = "Start by opening a blb file. Press 'File->Open' and navigate to the assets directory of the game";
             Pages.Clear();
@@ -356,12 +356,12 @@ namespace DieselBundleViewer.ViewModels
 
         public async Task OpenBLBFile(string filePath)
         {
-            Stopwatch timer = new Stopwatch();
+            Stopwatch timer = new();
             timer.Start();
 
             CloseBLBExec();
 
-            CancellationTokenSource CancelSource = new CancellationTokenSource();
+            CancellationTokenSource CancelSource = new();
             cancelLastTask = CancelSource;
 
             CloseBLB.RaiseCanExecuteChanged();
@@ -388,7 +388,7 @@ namespace DieselBundleViewer.ViewModels
 
                 bool foundHashlist = false;
 
-                List<string> FilterFiles = new List<string>();
+                List<string> FilterFiles = [];
                 for (int i = 0; i < Files.Count; i++)
                 {
                     if (CancelSource.IsCancellationRequested)
@@ -407,7 +407,7 @@ namespace DieselBundleViewer.ViewModels
 
                     Status = string.Format("Loading bundle {0} {1}/{2}", file, i, FilterFiles.Count);
 
-                    PackageHeader bundle = new PackageHeader();
+                    PackageHeader bundle = new();
                     if (!bundle.Load(file))
                         continue;
 
@@ -427,9 +427,9 @@ namespace DieselBundleViewer.ViewModels
                             }
                         }
 
-                        if (FileEntries.ContainsKey(be.ID))
+                        if (FileEntries.TryGetValue(be.ID, out FileEntry value))
                         {
-                            FileEntry fileEntry = FileEntries[be.ID];
+                            FileEntry fileEntry = value;
                             fileEntry.AddBundleEntry(be);
                             FolderEntry folderEntry = fileEntry.Parent;
                         }
@@ -445,8 +445,7 @@ namespace DieselBundleViewer.ViewModels
 
                     fe.LoadPath();
                     RawFiles.Add(new Tuple<Idstring, Idstring, Idstring>(fe.PathIds, fe.LanguageIds, fe.ExtensionIds), fe);
-                    if(Root != null)
-                        Root.Owner.AddFileEntry(fe);
+                    Root?.Owner.AddFileEntry(fe);
                 }
 
                 GC.Collect();
@@ -466,7 +465,7 @@ namespace DieselBundleViewer.ViewModels
 
             Status = $"Done. Took {timer.ElapsedMilliseconds / 1000} seconds";
 
-            Bundles = PackageHeaders.Keys.ToList();
+            Bundles = [.. PackageHeaders.Keys];
             FoldersToRender.Clear();
             FoldersToRender.Add(Root);
 
@@ -502,7 +501,7 @@ namespace DieselBundleViewer.ViewModels
 
         public void SetDir(LinkedListNode<PageData> dir)
         {
-            SetProperty(ref CurrentPage, dir, "CurrentDir");
+            SetProperty(ref CurrentPage, dir, nameof(CurrentDir));
             DirChanged();
         }
 
@@ -551,8 +550,8 @@ namespace DieselBundleViewer.ViewModels
 
             if (cancelLastTask == null)
             {
-                List<FileEntry> files = new List<FileEntry>();
-                List<FolderEntry> folders = new List<FolderEntry>();
+                List<FileEntry> files = [];
+                List<FolderEntry> folders = [];
 
                 PageData page = CurrentPage.Value;
 
@@ -564,7 +563,7 @@ namespace DieselBundleViewer.ViewModels
                 folders.Sort(SortEntry);
                 files.Sort(SortEntry);
 
-                List<EntryViewModel> list = new List<EntryViewModel>();
+                List<EntryViewModel> list = [];
                 bool firstFiles = page.SortBy != Sorting.Type && !page.Ascending;
                 if (firstFiles)
                 {
@@ -631,9 +630,7 @@ namespace DieselBundleViewer.ViewModels
 
             if (!asc)
             {
-                IEntry move = a;
-                a = b;
-                b = move;
+                (b, a) = (a, b);
             }
 
             int check = sortBy switch
@@ -651,11 +648,11 @@ namespace DieselBundleViewer.ViewModels
 
         public Dictionary<uint, FileEntry> DatabaseEntryToFileEntry(List<DatabaseEntry> entries)
         {
-            Dictionary<uint, FileEntry> fileEntries = new Dictionary<uint, FileEntry>();
+            Dictionary<uint, FileEntry> fileEntries = [];
 
             foreach (DatabaseEntry ne in entries)
             {
-                FileEntry fe = new FileEntry(ne);
+                FileEntry fe = new(ne);
                 fileEntries.Add(ne.ID, fe);
             }
             return fileEntries;
@@ -679,7 +676,7 @@ namespace DieselBundleViewer.ViewModels
 
         public List<EntryViewModel> SelectedEntries()
         {
-            List<EntryViewModel> list = new List<EntryViewModel>();
+            List<EntryViewModel> list = [];
             foreach(var entry in ToRender)
             {
                 if(entry.IsSelected)

--- a/ViewModels/MainWindowViewModel.cs
+++ b/ViewModels/MainWindowViewModel.cs
@@ -15,7 +15,6 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;

--- a/ViewModels/ProgressDialogViewModel.cs
+++ b/ViewModels/ProgressDialogViewModel.cs
@@ -1,31 +1,20 @@
 ﻿using DieselBundleViewer.Services;
-using DieselBundleViewer.Views;
 using Prism.Commands;
-using Prism.Events;
-using Prism.Mvvm;
-using Prism.Services.Dialogs;
+using Prism.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 
 namespace DieselBundleViewer.ViewModels
 {
-    public class ProgressRecord
+    public class ProgressRecord(string status, int total, int completed)
     {
-        public string Status { get; private set; }
-        public int Total { get; private set; }
-        public int Completed { get; private set; }
-
-        public ProgressRecord(string status, int total, int completed)
-        {
-            Status = status;
-            Total = total;
-            Completed = completed;
-        }
+        public string Status { get; private set; } = status;
+        public int Total { get; private set; } = total;
+        public int Completed { get; private set; } = completed;
     }
 
     public class ProgressDialogViewModel : DialogBase

--- a/ViewModels/PropertiesViewModel.cs
+++ b/ViewModels/PropertiesViewModel.cs
@@ -1,28 +1,21 @@
 ﻿using DieselBundleViewer.Models;
 using DieselEngineFormats.Bundle;
-using Prism.Commands;
-using System.Windows;
+using Prism.Dialogs;
 using Prism.Mvvm;
-using Prism.Services.Dialogs;
-using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using DieselBundleViewer.Services;
 
 namespace DieselBundleViewer.ViewModels
 {
-    public class PackageFileViewModel : BindableBase
+    public class PackageFileViewModel(PackageFileEntry entry) : BindableBase
     {
-        private PackageFileEntry _entry;
+        private PackageFileEntry _entry = entry;
 
         public string Name => _entry.PackageName.UnHashed;
         public string HashedName => _entry.PackageName.HashedString;
         public string Size => _entry.FileSize;
         public uint Address => _entry.Address;
         public int Length => _entry.Length;
-
-        public PackageFileViewModel(PackageFileEntry entry) => _entry = entry;
     }
 
     public class PropertiesViewModel : DialogBase
@@ -89,15 +82,15 @@ namespace DieselBundleViewer.ViewModels
         protected override void PostDialogOpened(IDialogParameters pms)
         {
             entryVM = pms.GetValue<EntryViewModel>("Entry");
-            RaisePropertyChanged("FileVisibility");
-            RaisePropertyChanged("FolderVisibility");
-            RaisePropertyChanged("Name");
-            RaisePropertyChanged("Icon");
-            RaisePropertyChanged("Type");
-            RaisePropertyChanged("Size");
-            RaisePropertyChanged("EntryPath");
-            RaisePropertyChanged("HashedName");
-            RaisePropertyChanged("FolderContains");
+            RaisePropertyChanged(nameof(FileVisibility));
+            RaisePropertyChanged(nameof(FolderVisibility));
+            RaisePropertyChanged(nameof(Name));
+            RaisePropertyChanged(nameof(Icon));
+            RaisePropertyChanged(nameof(Type));
+            RaisePropertyChanged(nameof(Size));
+            RaisePropertyChanged(nameof(EntryPath));
+            RaisePropertyChanged(nameof(HashedName));
+            RaisePropertyChanged(nameof(FolderContains));
 
             IEntry entry = entryVM.Owner;
             if(entry is FileEntry)

--- a/ViewModels/SettingsDialogViewModel.cs
+++ b/ViewModels/SettingsDialogViewModel.cs
@@ -1,10 +1,5 @@
 ﻿using DieselBundleViewer.Services;
-using Prism.Commands;
-using Prism.Mvvm;
-using Prism.Services.Dialogs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using Prism.Dialogs;
 
 namespace DieselBundleViewer.ViewModels
 {

--- a/ViewModels/TreeEntryViewModel.cs
+++ b/ViewModels/TreeEntryViewModel.cs
@@ -60,7 +60,7 @@ namespace DieselBundleViewer.ViewModels
                 IsExpanded = currentDir.StartsWith(Owner.EntryPath);
 
             if(wasExpanded != IsExpanded)
-                RaisePropertyChanged("IsExpanded");
+                RaisePropertyChanged(nameof(IsExpanded));
 
             if(isSelected != IsSelected)
                 IsSelected = currentDir == Owner.EntryPath;

--- a/ViewModels/UpdateHashlistDialogViewModel.cs
+++ b/ViewModels/UpdateHashlistDialogViewModel.cs
@@ -1,15 +1,13 @@
 ﻿using DieselBundleViewer.Services;
 using Prism.Dialogs;
 using System;
+using System.Windows;
 
 namespace DieselBundleViewer.ViewModels
 {
     public partial class UpdateHashlistDialogViewModel : DialogBase
     {
         public override string Title => "Hashlist Updater";
-
-        private DateTime? _localHashlistLMD = null;
-        private DateTime? _latestHashlistLMD = null;
 
         private string _hashlistText = "";
         public string UpdateWindowText
@@ -31,20 +29,36 @@ namespace DieselBundleViewer.ViewModels
 
             var hashlistStatus = HashlistUpdater.IsHashlistUpToDate();
 
-            if (hashlistStatus == null)
-            {
-                UpdateWindowText = "No hashlist found locally.";
-                DownloadButtonEnabled = true;
-            }
-            else if (hashlistStatus == true)
+            if (hashlistStatus == true)
             {
                 UpdateWindowText = "Hashlist is up to date.";
+                return;
+            }
+            else if (hashlistStatus == false)
+            {
+                UpdateWindowText = "Hashlist update found.";
             }
             else
             {
-                UpdateWindowText = "Hashlist update found. Please download.";
-                DownloadButtonEnabled = true;
+                UpdateWindowText = "No hashlist found locally.";
             }
+
+            DownloadButtonEnabled = true;
+        }
+
+        public async void Click_DownloadHashlist()
+        {
+            UpdateWindowText = "Downloading... please wait...";
+            DownloadButtonEnabled = false;
+
+            await HashlistUpdater.DownloadLatestHashlist();
+
+            UpdateWindowText = "Updated Hashlist.";
+
+            // Clear the Tree view if it was opened without- or with an old hashlist
+            var mainWindowViewModel = (MainWindowViewModel)Application.Current.MainWindow.DataContext;
+            if (mainWindowViewModel != null && mainWindowViewModel.Bundles != null && mainWindowViewModel.Bundles.Count > 0)
+                mainWindowViewModel.CloseBLB.Execute();
         }
     }
 }

--- a/ViewModels/UpdateHashlistDialogViewModel.cs
+++ b/ViewModels/UpdateHashlistDialogViewModel.cs
@@ -1,0 +1,76 @@
+﻿using DieselBundleViewer.Views;
+using Prism.Dialogs;
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json.Nodes;
+
+namespace DieselBundleViewer.ViewModels
+{
+    public partial class UpdateHashlistDialogViewModel : DialogBase
+    {
+        public override string Title => "Hashlist Updater";
+
+        private DateTime? _localHashlistLMD = null;
+        private DateTime? _latestHashlistLMD = null;
+
+        private string _hashlistText = "";
+        public string HashlistVersionDifference
+        {
+            get
+            {
+                return _hashlistText;
+            }
+            set
+            {
+                SetProperty(ref _hashlistText, value);
+            }
+        }
+
+        private bool _updateButtonEnabled = false;
+        public bool UpdateButtonEnabled
+        {
+            get
+            {
+                return _updateButtonEnabled;
+            }
+            set
+            {
+                SetProperty(ref _updateButtonEnabled, value);
+            }
+        }
+
+        protected override void PostDialogOpened(IDialogParameters pms)
+        {
+            base.PostDialogOpened(pms);
+
+            if (File.Exists("Data/hashlist"))
+                _localHashlistLMD = File.GetLastWriteTime("Data/hashlist");
+
+            using var client = new HttpClient();
+            // GitHub API has a free limit but not having a User-Agent excludes you from even that
+            client.DefaultRequestHeaders.Add(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:129.0) Gecko/20100101 Firefox/129.0"
+            );
+
+            var response = client.GetStringAsync("https://api.github.com/repos/Luffyyy/PAYDAY-2-Hashlist/branches/master");
+            var branchInfo = JsonNode.Parse(response.Result.ToString());
+
+            var latestDate = branchInfo?["commit"]["commit"]["author"]["date"]?.ToString();
+            if (latestDate != null)
+                _latestHashlistLMD = DateTime.Parse(latestDate);
+
+            if (!_localHashlistLMD.HasValue)
+                HashlistVersionDifference = "No hashlist found locally.";
+            else if (_latestHashlistLMD.HasValue && _localHashlistLMD >= _latestHashlistLMD)
+                HashlistVersionDifference = "Hashlist is up to date.";
+            else
+            {
+                HashlistVersionDifference = "Hashlist update found.";
+                UpdateButtonEnabled = true;
+            }
+        }
+    }
+}

--- a/Views/DialogWindow.xaml.cs
+++ b/Views/DialogWindow.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using AdonisUI.Controls;
-using Prism.Services.Dialogs;
-using System.Windows;
+using Prism.Dialogs;
 
 namespace DieselBundleViewer.Views
 {

--- a/Views/MainWindow.xaml
+++ b/Views/MainWindow.xaml
@@ -69,8 +69,9 @@
                     <MenuItem Header="Extract All" Command="{Binding ExtractAll}"/>
                 </MenuItem>
                 <MenuItem Header="Help">
-                    <MenuItem Header="About" Command="{Binding OpenAboutDialog}"/>
+                    <MenuItem Header="Update Hashlist" Command="{Binding OpenUpdateHashlistDialog}"/>
                     <MenuItem Header="How to Use" Command="{Binding OpenHowToUse}"/>
+                    <MenuItem Header="About" Command="{Binding OpenAboutDialog}"/>
                 </MenuItem>
             </Menu>
         </Canvas>

--- a/Views/MainWindow.xaml.cs
+++ b/Views/MainWindow.xaml.cs
@@ -1,12 +1,7 @@
 ﻿using AdonisUI.Controls;
 using DieselBundleViewer.Services;
 using DieselBundleViewer.ViewModels;
-using System;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
 using System.Windows.Input;
 
 namespace DieselBundleViewer.Views

--- a/Views/SettingsDialog.xaml
+++ b/Views/SettingsDialog.xaml
@@ -1,7 +1,7 @@
 ﻿<UserControl x:Class="DieselBundleViewer.Views.SettingsDialog"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:prism="http://prismlibrary.com/"             
+             xmlns:prism="http://prismlibrary.com/" xmlns:viewmodels="clr-namespace:DieselBundleViewer.ViewModels" xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              prism:ViewModelLocator.AutoWireViewModel="True"
              Width="400" Height="200">
     <DockPanel Margin="8" LastChildFill="False">

--- a/Views/UpdateHashlistDialog.xaml
+++ b/Views/UpdateHashlistDialog.xaml
@@ -4,17 +4,11 @@
              xmlns:prism="http://prismlibrary.com/" 
              xmlns:viewmodels="clr-namespace:DieselBundleViewer.ViewModels" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             prism:ViewModelLocator.AutoWireViewModel="True" Width="350" Height="200">
+             prism:ViewModelLocator.AutoWireViewModel="True" Width="350" Height="160">
     <Grid Margin="16">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="32"/>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="24"/>
-        </Grid.RowDefinitions>
-        <TextBlock TextAlignment="Center" Grid.Row="0" DockPanel.Dock="Top" FontSize="24" Text="Checking for Update..."/>
-        <StackPanel Grid.Row="1">
-            <TextBlock x:Name="UpdateNeededText" TextAlignment="Center" FontSize="18" Text="{Binding HashlistVersionDifference, UpdateSourceTrigger=PropertyChanged}" Margin="0,20,0,0"/>
-            <Button x:Name="UpdateButton" Height="30" Width="80" Margin="0,20,0,0" Content="Update" Visibility="{Binding UpdateButtonEnabled, Converter={StaticResource BoolToVis}}" CommandParameter="False" Click="Update_Click"/>
+        <StackPanel>
+            <TextBlock TextAlignment="Center" FontSize="24" Text="{Binding UpdateWindowText, UpdateSourceTrigger=PropertyChanged}" Margin="0,20,0,0"/>
+            <Button Height="30" Width="80" Margin="0,20,0,0" Content="Download" Visibility="{Binding DownloadButtonEnabled, Converter={StaticResource BoolToVis}}" CommandParameter="False" Click="Click_DownloadButton" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Views/UpdateHashlistDialog.xaml
+++ b/Views/UpdateHashlistDialog.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl x:Class="DieselBundleViewer.Views.UpdateHashlistDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/" 
+             xmlns:viewmodels="clr-namespace:DieselBundleViewer.ViewModels" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             prism:ViewModelLocator.AutoWireViewModel="True" Width="350" Height="200">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="32"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="24"/>
+        </Grid.RowDefinitions>
+        <TextBlock TextAlignment="Center" Grid.Row="0" DockPanel.Dock="Top" FontSize="24" Text="Checking for Update..."/>
+        <StackPanel Grid.Row="1">
+            <TextBlock x:Name="UpdateNeededText" TextAlignment="Center" FontSize="18" Text="{Binding HashlistVersionDifference, UpdateSourceTrigger=PropertyChanged}" Margin="0,20,0,0"/>
+            <Button x:Name="UpdateButton" Height="30" Width="80" Margin="0,20,0,0" Content="Update" Visibility="{Binding UpdateButtonEnabled, Converter={StaticResource BoolToVis}}" CommandParameter="False" Click="Update_Click"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/Views/UpdateHashlistDialog.xaml.cs
+++ b/Views/UpdateHashlistDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿using DieselBundleViewer.Services;
+﻿using DieselBundleViewer.ViewModels;
 using System.Windows.Controls;
 
 namespace DieselBundleViewer.Views
@@ -13,9 +13,9 @@ namespace DieselBundleViewer.Views
             InitializeComponent();
         }
 
-        private async void Click_DownloadButton(object sender, System.Windows.RoutedEventArgs e)
+        private void Click_DownloadButton(object sender, System.Windows.RoutedEventArgs e)
         {
-            await HashlistUpdater.DownloadLatestHashlist();
+            (DataContext as UpdateHashlistDialogViewModel).Click_DownloadHashlist();
         }
     }
 }

--- a/Views/UpdateHashlistDialog.xaml.cs
+++ b/Views/UpdateHashlistDialog.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System.ComponentModel;
+using System.IO;
+using System.Net.Http;
+using System.Windows.Controls;
+
+namespace DieselBundleViewer.Views
+{
+    /// <summary>
+    /// Interaction logic for UpdateHashlistDialog
+    /// </summary>
+    public partial class UpdateHashlistDialog : UserControl
+    {
+        public UpdateHashlistDialog()
+        {
+            InitializeComponent();
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void Update_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.Add(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:129.0) Gecko/20100101 Firefox/129.0"
+            );
+
+            var response = client.GetStringAsync("https://raw.githubusercontent.com/Luffyyy/PAYDAY-2-Hashlist/master/hashlist");
+
+            using var streamWriter = new StreamWriter("data/hashlist", false);
+            streamWriter.Write(response.Result.ToString());
+            streamWriter.Flush();
+            streamWriter.Close();
+
+            this.UpdateNeededText.Text = "Update completed. Please restart.";
+            this.UpdateButton.Content = "Restart";
+            this.UpdateButton.Click += UpdateButton_PostUpdate_Click;
+        }
+
+        private void UpdateButton_PostUpdate_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            System.Windows.Forms.Application.Restart();
+            System.Windows.Application.Current.Shutdown();
+        }
+    }
+}

--- a/Views/UpdateHashlistDialog.xaml.cs
+++ b/Views/UpdateHashlistDialog.xaml.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-using System.IO;
-using System.Net.Http;
+﻿using DieselBundleViewer.Services;
 using System.Windows.Controls;
 
 namespace DieselBundleViewer.Views
@@ -15,32 +13,9 @@ namespace DieselBundleViewer.Views
             InitializeComponent();
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void Update_Click(object sender, System.Windows.RoutedEventArgs e)
+        private async void Click_DownloadButton(object sender, System.Windows.RoutedEventArgs e)
         {
-            using var client = new HttpClient();
-            client.DefaultRequestHeaders.Add(
-                "User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:129.0) Gecko/20100101 Firefox/129.0"
-            );
-
-            var response = client.GetStringAsync("https://raw.githubusercontent.com/Luffyyy/PAYDAY-2-Hashlist/master/hashlist");
-
-            using var streamWriter = new StreamWriter("data/hashlist", false);
-            streamWriter.Write(response.Result.ToString());
-            streamWriter.Flush();
-            streamWriter.Close();
-
-            this.UpdateNeededText.Text = "Update completed. Please restart.";
-            this.UpdateButton.Content = "Restart";
-            this.UpdateButton.Click += UpdateButton_PostUpdate_Click;
-        }
-
-        private void UpdateButton_PostUpdate_Click(object sender, System.Windows.RoutedEventArgs e)
-        {
-            System.Windows.Forms.Application.Restart();
-            System.Windows.Application.Current.Shutdown();
+            await HashlistUpdater.DownloadLatestHashlist();
         }
     }
 }

--- a/Views/VirtualizingWrapPanel.cs
+++ b/Views/VirtualizingWrapPanel.cs
@@ -113,10 +113,9 @@ namespace DieselBundleViewer.Views
                     int itemIndex = firstVisibleItemIndex;
                     while (itemIndex <= lastVisibleItemIndex)
                     {
-                        bool newlyRealized = false;
 
                         // Get or create the child
-                        UIElement child = generator.GenerateNext(out newlyRealized) as UIElement;
+                        UIElement child = generator.GenerateNext(out bool newlyRealized) as UIElement;
                         if (newlyRealized)
                         {
                             // Figure out if we need to insert the child at the end or somewhere in the middle
@@ -328,7 +327,7 @@ namespace DieselBundleViewer.Views
             int row = itemIndex / childrenPerRow;
             int column = itemIndex % childrenPerRow;
 
-            double xCoordForItem = 0;
+            double xCoordForItem;
             if (HorizontalContentAlignment == WrapPanelAlignment.Left)
             {
                 xCoordForItem = column * this.ChildWidth;
@@ -398,20 +397,14 @@ namespace DieselBundleViewer.Views
             if (extent != this.extent)
             {
                 this.extent = extent;
-                if (this.owner != null)
-                {
-                    this.owner.InvalidateScrollInfo();
-                }
+                this.owner?.InvalidateScrollInfo();
             }
 
             // Update viewport
             if (availableSize != this.viewport)
             {
                 this.viewport = availableSize;
-                if (this.owner != null)
-                {
-                    this.owner.InvalidateScrollInfo();
-                }
+                this.owner?.InvalidateScrollInfo();
             }
         }
 
@@ -572,10 +565,7 @@ namespace DieselBundleViewer.Views
 
             this.offset.Y = offset;
 
-            if (this.owner != null)
-            {
-                this.owner.InvalidateScrollInfo();
-            }
+            this.owner?.InvalidateScrollInfo();
         }
     }
 }


### PR DESCRIPTION
Just did some light refactoring for starters.
Style recommendations have changed for a while.

Minor Changes:
- Moved to `.NET 8`
- Updated `Prism` to latest
- Updated `IronPython` to latest

Major Changes:
- Added update modal for Hashlist

The main use for this was to be able to update the Hashlist without having to navigate to the related repository on your own and having to drag and drop the file after download.

It's written reasonably safe but I can think of one or two cases that would break this.
I'm also not super familiar with Prism or WPF anymore so if there's some egregious in here comment on it.